### PR TITLE
Kibana version hardcoded to v4 as it is no longer latest version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kibana:latest
+FROM kibana:4
 
 RUN gosu kibana kibana plugin --install elastic/sense/latest
 


### PR DESCRIPTION
It is no longer possible to build docker container using kibana:latest version as current latest version (5) no longer support sense plugin.

Sense plugin is built-in in version 5.